### PR TITLE
Updated Tool Metrics Logic and Tracer ID Assignment in Notebooks

### DIFF
--- a/agentneo/execution/metrics/tool_metrics.py
+++ b/agentneo/execution/metrics/tool_metrics.py
@@ -28,7 +28,7 @@ def execute_tool_correctness_metric(
     trace_json: Dict[str, Any], config: Dict[str, Any]
 ) -> Dict[str, Any]:
     
-    # Extract query from the trace
+    # Extract query 
     try:
         query = trace_json["llm_calls"][0]["input_prompt"][0]["content"]
     except (IndexError, KeyError) as e:

--- a/agentneo/execution/metrics/tool_metrics.py
+++ b/agentneo/execution/metrics/tool_metrics.py
@@ -27,12 +27,20 @@ def determine_intended_tool(query: str, tools: list, config: Dict[str, Any]) -> 
 def execute_tool_correctness_metric(
     trace_json: Dict[str, Any], config: Dict[str, Any]
 ) -> Dict[str, Any]:
-
+    
     # Extract query from the trace
     try:
         query = trace_json["llm_calls"][0]["input_prompt"][0]["content"]
-    except:
-        query = ""
+    except (IndexError, KeyError) as e:
+        print(f"Error extracting query: {e}")
+        return {
+            "metric_name": "tool_correctness",
+            "config": config,
+            "result": {
+                "score": 0,
+                "reason": f"Unable to extract query from trace_json: {e}",
+            },
+        }
 
     # Find tool calls
     tool_calls = trace_json["tool_calls"]

--- a/agentneo/execution/metrics/tool_metrics.py
+++ b/agentneo/execution/metrics/tool_metrics.py
@@ -29,7 +29,10 @@ def execute_tool_correctness_metric(
 ) -> Dict[str, Any]:
 
     # Extract query from the trace
-    query = trace_json["llm_calls"][0]["input_prompt"][0]["content"]
+    try:
+        query = trace_json["llm_calls"][0]["input_prompt"][0]["content"]
+    except:
+        query = ""
 
     # Find tool calls
     tool_calls = trace_json["tool_calls"]

--- a/examples/AutoGen/autogen_calculator.ipynb
+++ b/examples/AutoGen/autogen_calculator.ipynb
@@ -276,7 +276,7 @@
    "source": [
     "# Execute metrics\n",
     "from agentneo import Execution\n",
-    "exe = Execution(session=neo_session, trace_id=2)\n",
+    "exe = Execution(session=neo_session, trace_id=tracer.trace_id)\n",
     "exe.execute(metric_list=['goal_decomposition_efficiency', 'goal_fulfillment_rate', 'tool_correctness_metric', 'tool_call_success_rate_metric'])\n",
     "metric_results = exe.get_results()"
    ]

--- a/examples/AutoGen/autogen_groupchat.ipynb
+++ b/examples/AutoGen/autogen_groupchat.ipynb
@@ -526,7 +526,7 @@
    "source": [
     "# Execute metrics\n",
     "from agentneo import Execution\n",
-    "exe = Execution(session=neo_session, trace_id=1)\n",
+    "exe = Execution(session=neo_session, trace_id=tracer.trace_id)\n",
     "exe.execute(metric_list=['goal_decomposition_efficiency', 'goal_fulfillment_rate', 'tool_correctness_metric', 'tool_call_success_rate_metric'])\n",
     "metric_results = exe.get_results()"
    ]


### PR DESCRIPTION
# Pull Request Template

## Description
This PR introduces two key modifications:

1) Added a try-except block for query extraction in the tool correctness metric to handle potential exceptions when retrieving the input prompt.
2) Updated the tracer ID assignment in autogen_calculator.ipynb and autogen_groupchat.ipynb to use tracer.trace_id instead of hardcoding tracer_id=1 or tracer_id=2.

## Related Issue
N/A

## Type of Change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
The changes have been tested by running the updated metrics logic and verifying the output against expected results. The notebooks were executed to ensure that the new tracer ID assignments are functioning as intended without errors.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Context

Before the modifications, an error occurred while executing the tool_correctness_metric. The error message indicated an IndexError: list index out of range, which was caused by attempting to access an element in the trace_json["llm_calls"] list that didn't exist.
The changes made introduced a try-except block around the query extraction logic. This adjustment allows the function to handle cases where the input_prompt is not present, defaulting to an empty string for the query instead of throwing an error.

## Impact on Roadmap
This PR aligns with our ongoing efforts to improve tool accuracy , ensuring that our metrics are more reliable and easier to maintain