### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/ragaai_catalyst/tracers/upload_traces.py
+++ b/ragaai_catalyst/tracers/upload_traces.py
@@ -88,7 +88,9 @@ class UploadTraces:
                 "Content-Type": "application/json",
             }
 
-        if "blob.core.windows.net" in presignedUrl:  # Azure
+        from urllib.parse import urlparse
+        parsed_url = urlparse(presignedUrl)
+        if parsed_url.hostname and parsed_url.hostname.endswith("blob.core.windows.net"):  # Azure
             headers["x-ms-blob-type"] = "BlockBlob"
         print(f"Uploading traces...")
         with open(filename) as f:


### PR DESCRIPTION
Potential fix for [https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/5](https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/5)

To fix the problem, we need to ensure that the URL is properly parsed and validated. Instead of checking for the substring "blob.core.windows.net" within the URL, we should parse the URL and check the hostname specifically. This will prevent malicious URLs from bypassing the check by embedding the allowed host in an unexpected location.

The best way to fix this is to use the `urlparse` function from the `urllib.parse` module to parse the URL and then check the hostname. We will update the `_put_presigned_url` method to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
