### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_code.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_code.py
@@ -74,7 +74,9 @@ def _put_zip_presigned_url(project_name, presignedUrl, filename):
             "Content-Type": "application/zip",
         }
 
-    if "blob.core.windows.net" in presignedUrl:  # Azure
+    from urllib.parse import urlparse
+    parsed_url = urlparse(presignedUrl)
+    if parsed_url.hostname == "blob.core.windows.net":  # Azure
         headers["x-ms-blob-type"] = "BlockBlob"
     print(f"Uploading code...")
     with open(filename, 'rb') as f:


### PR DESCRIPTION
Potential fix for [https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/4](https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/4)

To fix the problem, we need to parse the URL and check the hostname properly instead of using a substring check. This can be done using the `urlparse` function from the `urllib.parse` module. We will extract the hostname from the URL and then check if it matches the expected hostname "blob.core.windows.net".

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname matches "blob.core.windows.net".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
