### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
@@ -50,7 +50,9 @@ class UploadAgenticTraces:
                 "Content-Type": "application/json",
             }
 
-        if "blob.core.windows.net" in presignedUrl:  # Azure
+        from urllib.parse import urlparse
+        parsed_url = urlparse(presignedUrl)
+        if parsed_url.hostname == "blob.core.windows.net":  # Azure
             headers["x-ms-blob-type"] = "BlockBlob"
         print(f"Uploading agentic traces...")
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/3](https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/3)

To fix the problem, we need to ensure that the URL is properly parsed and the hostname is checked correctly. Instead of checking if "blob.core.windows.net" is a substring of the URL, we should parse the URL and verify that the hostname matches the expected value.

The best way to fix this without changing existing functionality is to use the `urlparse` function from the `urllib.parse` module to extract the hostname from the URL and then check if it matches "blob.core.windows.net". This approach ensures that the check is accurate and not vulnerable to substring manipulation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
