### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/ragaai_catalyst/tracers/llamaindex_callback.py
+++ b/ragaai_catalyst/tracers/llamaindex_callback.py
@@ -303,7 +303,9 @@ class LlamaIndexTracer:
                 "Content-Type": "application/json",
             }
 
-        if "blob.core.windows.net" in presignedUrl:  # Azure
+        from urllib.parse import urlparse
+        parsed_url = urlparse(presignedUrl)
+        if parsed_url.hostname == "blob.core.windows.net":  # Azure
             headers["x-ms-blob-type"] = "BlockBlob"
         print(f"Uploading traces...")
         with open(filename) as f:


### PR DESCRIPTION
Potential fix for [https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/1](https://github.com/raga-ai-hub/RagaAI-Catalyst/security/code-scanning/1)

To fix the problem, we need to ensure that the host of the URL is correctly validated. Instead of using a substring check, we should parse the URL using `urlparse` and then check the hostname. This will ensure that the URL is actually pointing to the intended host and not a maliciously crafted one.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname matches the expected host (`blob.core.windows.net`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
