### PR TITLE
fix: guard choices[0] and message=None before content access

### DIFF
--- a/examples/all_llm_provider/all_llm_provider.py
+++ b/examples/all_llm_provider/all_llm_provider.py
@@ -118,6 +118,8 @@ def _get_openai_response(
             temperature=temperature,
             max_tokens=max_tokens
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         print(f"Error with OpenAI API: {str(e)}")
@@ -189,6 +191,8 @@ def _get_azure_openai_response(
             temperature=temperature,
             max_tokens=max_tokens
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         print(f"Error with Azure OpenAI API: {str(e)}")
@@ -507,6 +511,8 @@ def _get_groq_response(
             temperature=temperature,
             max_tokens=max_tokens
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         print(f"Error with Groq: {str(e)}")

--- a/examples/custom_agents/travel_agent/tools.py
+++ b/examples/custom_agents/travel_agent/tools.py
@@ -44,6 +44,8 @@ def llm_call(prompt, max_tokens=512, model="gpt-4o-mini", name="default"):
         temperature=0.7,
     )
 
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content.strip()
 
 @trace_tool(name="weather_tool", tool_type="api")

--- a/ragaai_catalyst/redteaming/llm_generator.py
+++ b/ragaai_catalyst/redteaming/llm_generator.py
@@ -65,6 +65,8 @@ class LLMGenerator:
             kwargs["response_format"] = {"type": "json_object"}
             
             response = client.chat.completions.create(**kwargs)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             content = response.choices[0].message.content
 
             if isinstance(content, str):

--- a/ragaai_catalyst/redteaming/llm_generator_old.py
+++ b/ragaai_catalyst/redteaming/llm_generator_old.py
@@ -60,6 +60,8 @@ class LLMGenerator:
                 kwargs["response_format"] = {"type": "json_object"}
             
             response = self.client.chat.completions.create(**kwargs)
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             content = response.choices[0].message.content
 
             if isinstance(content, str):

--- a/ragaai_catalyst/tracers/agentic_tracing/tests/ai_travel_agent.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/tests/ai_travel_agent.py
@@ -34,6 +34,8 @@ def llm_call(prompt, max_tokens=512, model="gpt-3.5-turbo"):
         max_tokens=max_tokens,
         temperature=0.7,
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content.strip()
 
 @tracer.trace_tool(

--- a/tests/examples/all_llm_provider/all_llm_provider.py
+++ b/tests/examples/all_llm_provider/all_llm_provider.py
@@ -122,6 +122,8 @@ def _get_openai_response(
             temperature=temperature,
             max_tokens=max_tokens
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         print(f"Error with OpenAI API: {str(e)}")
@@ -193,6 +195,8 @@ def _get_azure_openai_response(
             temperature=temperature,
             max_tokens=max_tokens
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         print(f"Error with Azure OpenAI API: {str(e)}")
@@ -511,6 +515,8 @@ def _get_groq_response(
             temperature=temperature,
             max_tokens=max_tokens
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     except Exception as e:
         print(f"Error with Groq: {str(e)}")

--- a/tests/examples/custom_agents/travel_agent/tools.py
+++ b/tests/examples/custom_agents/travel_agent/tools.py
@@ -44,6 +44,8 @@ def llm_call(prompt, max_tokens=512, name="default", model_name="gpt-4o-mini", p
         temperature=0.7,
     )
 
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content.strip()
 
 @trace_tool(name="weather_tool", tool_type="api")

--- a/tests/test_catalyst/test_prompt_manager.py
+++ b/tests/test_catalyst/test_prompt_manager.py
@@ -61,6 +61,8 @@ def test_compile_prompt(prompt_manager):
             model="gpt-4o-mini",
             messages=prompt
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
     get_openai_response(compiled_prompt)
 
@@ -77,6 +79,8 @@ def test_compile_prompt_no_modelname(prompt_manager):
                 model="",
                 messages=prompt
             )
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             return response.choices[0].message.content
         get_openai_response(compiled_prompt)
 


### PR DESCRIPTION
## Summary

OpenAI-compatible APIs can return **empty `choices`** on error or rate-limiting, causing `IndexError` at `choices[0]`. Gemini additionally returns `choices[0].message = None` on `PROHIBITED_CONTENT` safety filtering (HTTP 200 — no exception raised), causing `AttributeError` at `.content`.

This PR adds the comprehensive guard:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
before every bare `choices[0].message.content` access.

## Files changed (8 files, 13 sites)

- `ragaai_catalyst/redteaming/llm_generator.py` — core redteaming generator
- `ragaai_catalyst/redteaming/llm_generator_old.py` — legacy generator
- `ragaai_catalyst/tracers/agentic_tracing/tests/ai_travel_agent.py`
- `examples/all_llm_provider/all_llm_provider.py` — OpenAI, Azure, Groq helpers
- `examples/custom_agents/travel_agent/tools.py`
- `tests/examples/all_llm_provider/all_llm_provider.py` — same providers in test copy
- `tests/examples/custom_agents/travel_agent/tools.py`
- `tests/test_catalyst/test_prompt_manager.py`

## Verification

The Gemini `choices[0].message = None` crash is documented with a live proof in [Gemini API docs — safety filtering](https://ai.google.dev/api/generate-content#v1beta.Candidate.FinishReason). Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule) found all 13 sites; post-fix scan returns 0 violations.